### PR TITLE
Fix sqlite3 compatibility.

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -94,7 +94,7 @@ func (a *Adapter) createDatabase() error {
 				return nil
 			}
 		}
-	} else {
+	} else if a.driverName != "sqlite3" {
 		_, err = engine.Exec("CREATE DATABASE IF NOT EXISTS casbin")
 	}
 	return err
@@ -116,6 +116,8 @@ func (a *Adapter) open() {
 
 		if a.driverName == "postgres" {
 			engine, err = xorm.NewEngine(a.driverName, a.dataSourceName+" dbname=casbin")
+		} else if a.driverName == "sqlite3" {
+			engine, err = xorm.NewEngine(a.driverName, a.dataSourceName)
 		} else {
 			engine, err = xorm.NewEngine(a.driverName, a.dataSourceName+"casbin")
 		}


### PR DESCRIPTION
See explanation: https://github.com/casbin/gorm-adapter/pull/10#issue-261883480

Basically for sqlite, the query create database should not be executed nor should the database name be appended to the data source. This will cause panics.