### PR TITLE
Add locks for exposed apis for safe concurrent use

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -169,16 +169,10 @@ func (a *Adapter) close() error {
 }
 
 func (a *Adapter) createTable() error {
-	a.Lock()
-	defer a.Unlock()
-
 	return a.engine.Sync2(new(CasbinRule))
 }
 
 func (a *Adapter) dropTable() error {
-	a.Lock()
-	defer a.Unlock()
-
 	return a.engine.DropTables(new(CasbinRule))
 }
 
@@ -217,6 +211,9 @@ func loadPolicyLine(line *CasbinRule, model model.Model) {
 
 // LoadPolicy loads policy from database.
 func (a *Adapter) LoadPolicy(model model.Model) error {
+	a.Lock()
+	defer a.Unlock()
+
 	var lines []*CasbinRule
 	if err := a.engine.Find(&lines); err != nil {
 		return err
@@ -257,6 +254,9 @@ func savePolicyLine(ptype string, rule []string) *CasbinRule {
 
 // SavePolicy saves policy to database.
 func (a *Adapter) SavePolicy(model model.Model) error {
+	a.Lock()
+	defer a.Unlock()
+
 	err := a.dropTable()
 	if err != nil {
 		return err
@@ -288,6 +288,9 @@ func (a *Adapter) SavePolicy(model model.Model) error {
 
 // AddPolicy adds a policy rule to the storage.
 func (a *Adapter) AddPolicy(sec string, ptype string, rule []string) error {
+	a.Lock()
+	defer a.Unlock()
+
 	line := savePolicyLine(ptype, rule)
 	_, err := a.engine.Insert(line)
 	return err
@@ -295,6 +298,9 @@ func (a *Adapter) AddPolicy(sec string, ptype string, rule []string) error {
 
 // RemovePolicy removes a policy rule from the storage.
 func (a *Adapter) RemovePolicy(sec string, ptype string, rule []string) error {
+	a.Lock()
+	defer a.Unlock()
+
 	line := savePolicyLine(ptype, rule)
 	_, err := a.engine.Delete(line)
 	return err
@@ -302,6 +308,9 @@ func (a *Adapter) RemovePolicy(sec string, ptype string, rule []string) error {
 
 // RemoveFilteredPolicy removes policy rules that match the filter from the storage.
 func (a *Adapter) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) error {
+	a.Lock()
+	defer a.Unlock()
+
 	line := &CasbinRule{PType: ptype}
 
 	idx := fieldIndex + len(fieldValues)


### PR DESCRIPTION
A routine should only release the lock when it's done with the entire `SavePolicy()` and other operations.
https://github.com/casbin/xorm-adapter/blob/master/adapter.go#L258-L287
```go
// SavePolicy saves policy to database.
func (a *Adapter) SavePolicy(model model.Model) error {
	err := a.dropTable()
	if err != nil {
		return err
	}
	err = a.createTable()
	if err != nil {
		return err
	}

	var lines []*CasbinRule

	for ptype, ast := range model["p"] {
		for _, rule := range ast.Policy {
			line := savePolicyLine(ptype, rule)
			lines = append(lines, line)
		}
	}

	for ptype, ast := range model["g"] {
		for _, rule := range ast.Policy {
			line := savePolicyLine(ptype, rule)
			lines = append(lines, line)
		}
	}

	_, err = a.engine.Insert(&lines)
	return err
}
```
For instance, consider the following scenario where two routines (A and B) are calling `savePolicy()` at the same time. 
1. Routine A and B both wait on the lock on `dropTable()`
2. Routine A gets the lock and proceeds to drop the table.
3. Routine A releases the lock.
4. Routine B obtains the lock and proceeds to drop the table. However, the table is already dropped as Routine A dropped it earlier but has not created it yet and is waiting on the lock to be released by Routine B.

I hope this is clear enough. This is only one of many scenarios I can think of when things might be problematic.